### PR TITLE
feat: 회원 가입 도메인 및 저장소 구현

### DIFF
--- a/src/main/java/hello/login/TestDataInit.java
+++ b/src/main/java/hello/login/TestDataInit.java
@@ -2,6 +2,8 @@ package hello.login;
 
 import hello.login.domain.item.Item;
 import hello.login.domain.item.ItemRepository;
+import hello.login.domain.member.Member;
+import hello.login.domain.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -12,6 +14,7 @@ import javax.annotation.PostConstruct;
 public class TestDataInit {
 
     private final ItemRepository itemRepository;
+    private final MemberRepository memberRepository;
 
     /**
      * 테스트용 데이터 추가
@@ -20,6 +23,13 @@ public class TestDataInit {
     public void init() {
         itemRepository.save(new Item("itemA", 10000, 10));
         itemRepository.save(new Item("itemB", 20000, 20));
+
+        Member member = new Member();
+        member.setLoginId("test");
+        member.setPassword("test!");
+        member.setName("테스터");
+
+        memberRepository.save(member);
     }
 
 }

--- a/src/main/java/hello/login/domain/member/Member.java
+++ b/src/main/java/hello/login/domain/member/Member.java
@@ -1,0 +1,18 @@
+package hello.login.domain.member;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotEmpty;
+
+@Data
+public class Member {
+
+    private Long id;
+
+    @NotEmpty
+    private String loginId;
+    @NotEmpty
+    private String name;
+    @NotEmpty
+    private String password;
+}

--- a/src/main/java/hello/login/domain/member/MemberRepository.java
+++ b/src/main/java/hello/login/domain/member/MemberRepository.java
@@ -1,0 +1,39 @@
+package hello.login.domain.member;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Slf4j
+@Repository
+public class MemberRepository {
+
+    private static Map<Long, Member> store = new HashMap<>();
+    private static long sequence = 0L;
+
+    public Member save(Member member) {
+        member.setId(++sequence);
+        log.info("save : member={}", member);
+        store.put(member.getId(), member);
+        return member;
+    }
+
+    public Member findById(Long id) {
+        return store.get(id);
+    }
+
+    public Optional<Member> findByLoginId(String loginId) {
+        return findAll().stream()
+                .filter(m -> m.getLoginId().equals(loginId))
+                .findFirst();
+    }
+
+    public List<Member> findAll() {
+        return new ArrayList<>(store.values());
+    }
+
+    public void clearStore() {
+        store.clear();
+    }
+}

--- a/src/main/java/hello/login/web/member/MemberController.java
+++ b/src/main/java/hello/login/web/member/MemberController.java
@@ -1,0 +1,35 @@
+package hello.login.web.member;
+
+import hello.login.domain.member.Member;
+import hello.login.domain.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.validation.Valid;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+    private final MemberRepository memberRepository;
+
+    @GetMapping("/add")
+    public String addForm(@ModelAttribute("member") Member member) {
+        return "members/addMemberForm";
+    }
+
+    @PostMapping("/add")
+    public String save(@Valid @ModelAttribute Member member, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return "members/addMemberForm";
+        }
+
+        memberRepository.save(member);
+        return "redirect:/";
+    }
+}

--- a/src/main/resources/templates/members/addMemberForm.html
+++ b/src/main/resources/templates/members/addMemberForm.html
@@ -1,0 +1,62 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <link th:href="@{/css/bootstrap.min.css}"
+          href="../css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .container {
+            max-width: 560px;
+        }
+        .field-error {
+            border-color: #dc3545;
+            color: #dc3545;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="py-5 text-center">
+        <h2>회원 가입</h2>
+    </div>
+    <h4 class="mb-3">회원 정보 입력</h4>
+    <form action="" th:action th:object="${member}" method="post">
+        <div th:if="${#fields.hasGlobalErrors()}">
+            <p class="field-error" th:each="err : ${#fields.globalErrors()}"
+               th:text="${err}">전체 오류 메시지</p>
+        </div>
+        <div>
+            <label for="loginId">로그인 ID</label>
+            <input type="text" id="loginId" th:field="*{loginId}" class="form-control"
+                   th:errorclass="field-error">
+            <div class="field-error" th:errors="*{loginId}"/>
+        </div>
+        <div>
+            <label for="password">비밀번호</label>
+            <input type="password" id="password" th:field="*{password}"
+                   class="form-control"
+                   th:errorclass="field-error">
+            <div class="field-error" th:errors="*{password}" />
+        </div>
+        <div>
+            <label for="name">이름</label>
+            <input type="text" id="name" th:field="*{name}" class="form-control"
+                   th:errorclass="field-error">
+            <div class="field-error" th:errors="*{name}" />
+        </div>
+        <hr class="my-4">
+        <div class="row">
+            <div class="col">
+                <button class="w-100 btn btn-primary btn-lg" type="submit">회원 가입</button>
+            </div>
+            <div class="col">
+                <button class="w-100 btn btn-secondary btn-lg"
+                        onclick="location.href='items.html'"
+                        th:onclick="|location.href='@{/}'|"
+                        type="button">취소</button>
+            </div>
+        </div>
+    </form>
+</div> <!-- /container -->
+</body>
+</html>


### PR DESCRIPTION
### 작업 내용
- 회원 도메인(Member) 클래스 생성 및 유효성 검증 적용
- 메모리 기반 회원 저장소(MemberRepository) 구현
- 회원 가입 컨트롤러 및 폼 처리 로직 작성
- Thymeleaf 기반 회원 가입 화면 템플릿 추가
- 테스트용 회원 데이터 초기화 처리(@PostConstruct)

### 테스트 방법
- `/members/add` 접속 후 유효한 값 입력 시 가입 성공 및 홈으로 리다이렉트
- 미입력 필드 존재 시 유효성 오류 메시지 출력 확인
- 초기 계정 test/test! 정상 등록 확인
