### PR TITLE
feat: 직접 구현한 세션 관리 기능 추가

### DIFF
--- a/src/main/java/hello/login/web/session/SessionManager.java
+++ b/src/main/java/hello/login/web/session/SessionManager.java
@@ -1,0 +1,57 @@
+package hello.login.web.session;
+
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+
+@Component
+public class SessionManager {
+
+    public static final String SESSION_COOKE_NAME = "mySessionId";
+    private Map<String, Object> sessionStore = new ConcurrentHashMap<>();
+
+    public void createSession(Object value, HttpServletResponse response) {
+        //세션 id를 생성하고, 값을 세션에 저장
+        String sessionId = UUID.randomUUID().toString();
+        sessionStore.put(sessionId, value);
+
+        //쿠키 생성
+        Cookie mySessionCookie = new Cookie(SESSION_COOKE_NAME, sessionId);
+        response.addCookie(mySessionCookie);
+    }
+
+    //세션 조회
+    public Object getSession(HttpServletRequest request) {
+        Cookie sessionCookie = findCookie(request, SESSION_COOKE_NAME);
+        if (sessionCookie == null) {
+            return null;
+        }
+        return sessionStore.get(sessionCookie.getValue());
+    }
+
+    //세션 만료
+    public void expire(HttpServletRequest request) {
+        Cookie sessionCookie = findCookie(request, SESSION_COOKE_NAME);
+        if (sessionCookie != null) {
+            sessionStore.remove(sessionCookie.getValue());
+        }
+    }
+
+    public Cookie findCookie(HttpServletRequest request, String cookieName) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(cookieName))
+                .findAny()
+                .orElse(null);
+    }
+
+}

--- a/src/test/java/hello/login/web/session/SessionManagerTest.java
+++ b/src/test/java/hello/login/web/session/SessionManagerTest.java
@@ -1,0 +1,34 @@
+package hello.login.web.session;
+
+import hello.login.domain.member.Member;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SessionManagerTest {
+    SessionManager sessionManager = new SessionManager();
+
+    @Test
+    void sessionTest() {
+        //세션 생성
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        Member member = new Member();
+        sessionManager.createSession(member, response);
+
+        //요청에 응답 쿠키 저장
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(response.getCookies());
+
+        //세션 조회
+        Object result = sessionManager.getSession(request);
+        assertThat(result).isEqualTo(member);
+
+        //세션 만료
+        sessionManager.expire(request);
+        Object expired = sessionManager.getSession(request);
+        assertThat(expired).isNull();
+
+    }
+}


### PR DESCRIPTION
### 구현 내용
- SessionManager를 구현하여 세션 직접 관리 기능 추가
- createSession(), getSession(), expire() 기능 구현
- 세션 ID는 UUID 기반으로 생성하고, 쿠키를 통해 클라이언트에 전달
- 세션 저장소는 ConcurrentHashMap을 사용하여 동시성 문제 해결
- 단위 테스트에서는 MockHttpServletRequest, MockHttpServletResponse 활용

