### PR TITLE
feat: 서블릿 HttpSession을 이용한 로그인/로그아웃/홈 화면 처리 구현

### DIFF
--- a/src/main/java/hello/login/web/HomeController.java
+++ b/src/main/java/hello/login/web/HomeController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 @Slf4j
 @Controller
@@ -41,7 +42,7 @@ public class HomeController {
         return "loginHome";
     }
 
-    @GetMapping("/")
+//    @GetMapping("/")
     public String homeLoginV2(HttpServletRequest request, Model model) {
 
         //세션 관리자에 저장된 회원 정보 조회
@@ -52,6 +53,25 @@ public class HomeController {
             return "home";
         }
         model.addAttribute("member", member);
+        return "loginHome";
+    }
+
+    @GetMapping("/")
+    public String homeLoginV3(HttpServletRequest request, Model model) {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return "home";
+        }
+
+        Member loginMember = (Member) session.getAttribute(SessionConst.LOGIN_MEMBER);
+
+        //세션에 회원 데이터가 없으면 home
+        if (loginMember == null) {
+            return "home";
+        }
+
+        //세션이 유지되면 로그인으로 이동
+        model.addAttribute("member", loginMember);
         return "loginHome";
     }
 }

--- a/src/main/java/hello/login/web/SessionConst.java
+++ b/src/main/java/hello/login/web/SessionConst.java
@@ -1,0 +1,5 @@
+package hello.login.web;
+
+public class SessionConst {
+    public static final String LOGIN_MEMBER = "loginMember";
+}

--- a/src/main/java/hello/login/web/login/LoginController.java
+++ b/src/main/java/hello/login/web/login/LoginController.java
@@ -2,6 +2,7 @@ package hello.login.web.login;
 
 import hello.login.domain.login.LoginService;
 import hello.login.domain.member.Member;
+import hello.login.web.SessionConst;
 import hello.login.web.session.SessionManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
 @Slf4j
@@ -49,7 +51,7 @@ public class LoginController {
         return "redirect:/";
     }
 
-    @PostMapping("/login")
+//    @PostMapping("/login")
     public String loginV2(@Valid @ModelAttribute LoginForm form, BindingResult bindingResult, HttpServletResponse response) {
         if (bindingResult.hasErrors()) {
             return "login/loginForm";
@@ -68,15 +70,45 @@ public class LoginController {
         return "redirect:/";
     }
 
+    @PostMapping("/login")
+    public String loginV3(@Valid @ModelAttribute LoginForm form, BindingResult bindingResult, HttpServletRequest request) {
+        if (bindingResult.hasErrors()) {
+            return "login/loginForm";
+        }
+        Member loginMember = loginService.login(form.getLoginId(), form.getPassword());
+
+        if (loginMember == null) {
+            bindingResult.reject("loginFail", "아이디 또는 비밀번호가 맞지 않습니다.");
+            return "login/loginForm";
+        }
+
+        //로그인 성공 처리
+        //세션이 있으면 있는 세션 반환, 없으면 신규 세션을 생성
+        HttpSession session = request.getSession();
+        //세션에 로그인 회원 정보 보관
+        session.setAttribute(SessionConst.LOGIN_MEMBER, loginMember);
+
+        return "redirect:/";
+    }
+
 //    @PostMapping("/logout")
     public String logout(HttpServletResponse response) {
         expireCookie(response, "memberId");
         return "redirect:/";
     }
 
-    @PostMapping("/logout")
+//    @PostMapping("/logout")
     public String logoutV2(HttpServletRequest request) {
         sessionManager.expire(request);
+        return "redirect:/";
+    }
+
+    @PostMapping("/logout")
+    public String logoutV3(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
         return "redirect:/";
     }
 


### PR DESCRIPTION
### 구현 내용
- LoginController.loginV3(): 로그인 성공 시 HttpSession 생성 및 회원 객체 저장
- LoginController.logoutV3(): HttpSession.invalidate()로 세션 만료 처리
- HomeController.homeLoginV3(): 세션에서 회원 정보 조회 후 로그인 여부 판단
- SessionConst 클래스 추가: 세션 키 문자열 상수 정의

### 적용 이유
- 기존 직접 구현한 세션(SessionManager) 방식에서 서블릿 표준 기능(HttpSession)으로 전환
- 민감한 정보를 쿠키에 저장하지 않고, 서버에 안전하게 보관
- 예측 불가능한 세션 ID(JSESSIONID)로 클라이언트-서버 간 상태 유지

### 참고 사항
- 기존 loginV2, logoutV2, homeLoginV2 메서드는 주석 처리하여 유지
- 세션 조회 시 request.getSession(false) 사용하여 불필요한 세션 생성 방지
