### PR TITLE
feat: 세션 정보 출력 및 타임아웃 설정 기능 추가

### DIFF
--- a/src/main/java/hello/login/web/session/SessionInfoController.java
+++ b/src/main/java/hello/login/web/session/SessionInfoController.java
@@ -1,0 +1,35 @@
+package hello.login.web.session;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.util.Date;
+
+@Slf4j
+@RestController
+public class SessionInfoController {
+
+    @GetMapping("/session-info")
+    public String sessioninfo(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return "세션이 없습니다.";
+        }
+
+        //세션 데이터 출력
+        session.getAttributeNames().asIterator()
+                .forEachRemaining(name -> log.info("session name={}, value={}", name, session.getAttribute(name)));
+
+        log.info("sessionId={}", session.getId());
+        log.info("sessionId={}", session.getMaxInactiveInterval());
+        log.info("creationTime={}", new Date(session.getCreationTime()));
+        log.info("LastAccessedTime={}", new Date(session.getLastAccessedTime()));
+        log.info("isNew={}", session.isNew());
+
+        return "세션 출력";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,4 @@
 spring.messages.basename=messages,errors
 
 server.servlet.session.tracking-modes=cookie
+server.servlet.session.timeout=60


### PR DESCRIPTION
### 작업 내용
- SessionInfoController를 통해 세션 주요 정보 로그 출력 기능 추가
- application.properties에서 전역 세션 타임아웃 설정 (`server.servlet.session.timeout=60`)

### 주요 변경 파일
- SessionInfoController.java
- application.properties
