### PR TITLE
feat: 요청 로그 필터 추가

### DIFF
--- a/src/main/java/hello/login/WebConfig.java
+++ b/src/main/java/hello/login/WebConfig.java
@@ -1,0 +1,22 @@
+package hello.login;
+
+import hello.login.web.filter.LogFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.servlet.Filter;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public FilterRegistrationBean logFilter() {
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new LogFilter());
+        filterRegistrationBean.setOrder(1);
+        filterRegistrationBean.addUrlPatterns("/*");
+
+        return filterRegistrationBean;
+    }
+}

--- a/src/main/java/hello/login/web/filter/LogFilter.java
+++ b/src/main/java/hello/login/web/filter/LogFilter.java
@@ -1,0 +1,40 @@
+package hello.login.web.filter;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+public class LogFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+      log.info("log filter init");
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        log.info("log filter doFilter");
+        HttpServletRequest httpRequst = (HttpServletRequest) request;
+        String requestURI = httpRequst.getRequestURI();
+
+        String uuid = UUID.randomUUID().toString();
+
+        try {
+            log.info("REQUEST [{}][{}]", uuid, requestURI);
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            log.info("RESPONSE [{}][{}]", uuid, requestURI);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        log.info("log filter destroy");
+    }
+}


### PR DESCRIPTION
### 작업 내용
- LogFilter 클래스 구현
  - 요청 및 응답에 대해 UUID와 요청 URI를 로그로 기록
  - 요청 식별을 위해 UUID 생성
- WebConfig 설정
  - FilterRegistrationBean으로 LogFilter 등록
  - 모든 URL 패턴(/*)에 필터 적용
  - 필터 실행 순서를 1로 설정
