### PR TITLE
feat: 로그인 인증 체크 인터셉터 추가

### DIFF
--- a/src/main/java/hello/login/WebConfig.java
+++ b/src/main/java/hello/login/WebConfig.java
@@ -3,6 +3,7 @@ package hello.login;
 import hello.login.web.filter.LogFilter;
 import hello.login.web.filter.LoginCheckFilter;
 import hello.login.web.interceptor.LogInterceptor;
+import hello.login.web.interceptor.LoginCheckInterceptor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +21,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .order(1)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/css/**", "/*.ico", "/error");
+
+        registry.addInterceptor(new LoginCheckInterceptor())
+                .order(2)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/", "/members/add", "/login", "/logout", "/css/**", "/*.ico", "/error");
     }
 
 //    @Bean
@@ -32,7 +38,7 @@ public class WebConfig implements WebMvcConfigurer {
         return filterRegistrationBean;
     }
 
-    @Bean
+//    @Bean
     public FilterRegistrationBean loginCheckFilter() {
         FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
         filterRegistrationBean.setFilter(new LoginCheckFilter());

--- a/src/main/java/hello/login/web/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/hello/login/web/interceptor/LoginCheckInterceptor.java
@@ -1,0 +1,29 @@
+package hello.login.web.interceptor;
+
+import hello.login.web.SessionConst;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+@Slf4j
+public class LoginCheckInterceptor implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        String requestURI = request.getRequestURI();
+        log.info("인증 체크 인터셉터 실행 {}", requestURI);
+
+        HttpSession session = request.getSession();
+
+        if (session == null || session.getAttribute(SessionConst.LOGIN_MEMBER) == null) {
+            log.info("미인증 사용자 요청");
+            response.sendRedirect("/login?redirectURL=" + requestURI);
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
서블릿 필터 기반 인증 체크를 스프링 인터셉터 방식으로 개선

### 작업 내용
- LoginCheckInterceptor 클래스 구현
  - preHandle에서 로그인 인증 여부 검증
  - 세션 미존재 또는 로그인 정보 미보유 시 로그인 페이지로 redirect
  - redirectURL 파라미터로 원래 요청 경로를 전달하여 로그인 후 복귀 가능
- WebConfig 수정
  - LoginCheckInterceptor 등록
  - 로그 인터셉터 이후 실행되도록 순서 지정(order=2)
  - 예외 경로(/, /members/add, /login, /logout, /css/**, /*.ico, /error) 설정

