### PR TITLE
feat: @Login 애노테이션과 ArgumentResolver를 통한 로그인 회원 주입 기능 추가

### DIFF
--- a/src/main/java/hello/login/WebConfig.java
+++ b/src/main/java/hello/login/WebConfig.java
@@ -1,5 +1,6 @@
 package hello.login;
 
+import hello.login.web.argumentresolver.LoginMemberArgumentResolver;
 import hello.login.web.filter.LogFilter;
 import hello.login.web.filter.LoginCheckFilter;
 import hello.login.web.interceptor.LogInterceptor;
@@ -7,13 +8,19 @@ import hello.login.web.interceptor.LoginCheckInterceptor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import javax.servlet.Filter;
+import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginMemberArgumentResolver());
+    }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {

--- a/src/main/java/hello/login/web/HomeController.java
+++ b/src/main/java/hello/login/web/HomeController.java
@@ -2,6 +2,7 @@ package hello.login.web;
 
 import hello.login.domain.member.Member;
 import hello.login.domain.member.MemberRepository;
+import hello.login.web.argumentresolver.Login;
 import hello.login.web.session.SessionManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -76,8 +77,20 @@ public class HomeController {
         return "loginHome";
     }
 
-    @GetMapping("/")
+//    @GetMapping("/")
     public String homeLoginV3Spring(@SessionAttribute(name = SessionConst.LOGIN_MEMBER, required = false) Member loginMember, Model model) {
+        //세션에 회원 데이터가 없으면 home
+        if (loginMember == null) {
+            return "home";
+        }
+
+        //세션이 유지되면 로그인으로 이동
+        model.addAttribute("member", loginMember);
+        return "loginHome";
+    }
+
+    @GetMapping("/")
+    public String homeLoginV3ArgumentResolver(@Login Member loginMember, Model model) {
         //세션에 회원 데이터가 없으면 home
         if (loginMember == null) {
             return "home";

--- a/src/main/java/hello/login/web/argumentresolver/Login.java
+++ b/src/main/java/hello/login/web/argumentresolver/Login.java
@@ -1,0 +1,11 @@
+package hello.login.web.argumentresolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}

--- a/src/main/java/hello/login/web/argumentresolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/hello/login/web/argumentresolver/LoginMemberArgumentResolver.java
@@ -1,0 +1,41 @@
+package hello.login.web.argumentresolver;
+
+import hello.login.domain.member.Member;
+import hello.login.web.SessionConst;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+@Slf4j
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver{
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        log.info("supportsParameter 실행");
+
+        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
+        boolean hasMemberType = Member.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasLoginAnnotation && hasMemberType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        log.info("resolverArgument 실행");
+
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        HttpSession session = request.getSession(false);
+
+        if (session == null) {
+            return null;
+        }
+
+        return session.getAttribute(SessionConst.LOGIN_MEMBER);
+    }
+}


### PR DESCRIPTION
### 작업 내용
- @Login 애노테이션 추가
- LoginMemberArgumentResolver 구현
  - 세션에서 로그인 회원 객체(Member) 자동 주입
  - 세션이 없을 경우 null 반환
- WebConfig 수정
  - addArgumentResolvers() 오버라이드로 커스텀 ArgumentResolver 등록
- HomeController 개선
  - 세션 조회 코드 제거
  - @Login Member loginMember 파라미터 활용으로 코드 간결화

### 변경 사유
- 중복되는 세션 조회 로직 제거
- 공통 관심사(로그인 회원 조회)를 ArgumentResolver로 분리하여 관리

### 실행 결과
- 로그인하지 않은 경우: loginMember = null → home 화면 이동
- 로그인한 경우: 세션의 Member 객체 주입 → loginHome 화면 이동
